### PR TITLE
server : add --reasoning-cache

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -3003,6 +3003,14 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_examples({LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_MAIN}).set_env("LLAMA_ARG_THINK_BUDGET"));
     add_opt(common_arg(
+        {"--reasoning-cache"}, "N",
+        "controls the reasoning cache size for models that require reasoning content during inference. (default: 0)",
+        [](common_params & params, int value) {
+            if (value < 0) { throw std::invalid_argument("invalid value"); }
+            params.reasoning_cache = value;
+        }
+    ).set_examples({LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_MAIN}).set_env("LLAMA_ARG_REASONING_CACHE"));
+    add_opt(common_arg(
         {"--chat-template"}, "JINJA_TEMPLATE",
         string_format(
             "set custom jinja chat template (default: template taken from model's metadata)\n"

--- a/common/common.h
+++ b/common/common.h
@@ -428,6 +428,7 @@ struct common_params {
     bool enable_chat_template = true;
     common_reasoning_format reasoning_format = COMMON_REASONING_FORMAT_AUTO;
     int reasoning_budget = -1;
+    int reasoning_cache = 0;
     bool prefill_assistant = true;                                                                          // if true, any trailing assistant message will be prefilled into the response
 
     std::vector<std::string> api_keys;

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -672,8 +672,25 @@ struct reasoning_cache {
         }
 
         for (auto &msg : messages) {
+            std::string role = json_value(msg, "role", std::string());
+            if (role != "assistant") {
+                continue;
+            }
+
             if (!msg.contains("tool_calls") || msg.contains("reasoning_content")) {
                 continue;
+            }
+
+            // do not inject if the message contains a non-empty content
+            if (msg.contains("content")) {
+                if (msg.at("content").is_string()) {
+                    std::string content = json_value(msg, "content", std::string());
+                    if (!content.empty()) {
+                        continue;
+                    }
+                } else if (!msg.at("content").empty()) {
+                    continue;
+                }
             }
 
             // inject cached reasoning to tool call messages to support models that require it (gpt-oss)


### PR DESCRIPTION
`gpt-oss` requires reasoning content from previous interactions to perform well.

This implements a reasoning cache, controlled by `--reasoning-cache` to store the reasoning content from tool call messages. On subsequent requests, the reasoning content is injected into the message. Since regular messages don't have an associated id, it will not add reasoning content to them. This aligns with the [recommendations by OpenAI](https://cookbook.openai.com/articles/openai-harmony#handling-reasoning-output-in-subsequent-sampling)

To use, pass in `--reasoning-cache 128`.

Unfortunately, it won't work well when placed behind llama-swap with a ttl, as it will kill the process and the cache with it.