### PR TITLE
server : determine context checkpoint positions ahead of time

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -215,6 +215,9 @@ struct server_slot {
 
     server_prompt prompt;
 
+    // positions where context checkpoints will be created for the current task (ascending, unique)
+    std::vector<int32_t> checkpoint_pos;
+
     bool prompt_save(server_prompt_cache & prompt_cache) const {
         if (prompt.tokens.size() == 0) {
             return false;
@@ -317,6 +320,7 @@ struct server_slot {
         }
         generated_tokens.clear();
         generated_token_probs.clear();
+        checkpoint_pos.clear();
         json_schema = json();
 
         // clear speculative decoding stats
@@ -3365,6 +3369,81 @@ private:
 
                         slot.prompt.tokens.keep_first(n_past);
 
+                        // determine ahead of time the positions at which context checkpoints will be created,
+                        // so that the prompt batches are split only at positions where a checkpoint is actually created
+                        slot.checkpoint_pos.clear();
+
+                        // make checkpoints only for completion tasks and only if:
+                        // - the model does not support partial sequence removal
+                        // - the model uses SWA (and we are not using `swa_full`)
+                        // - the model supports partial sequence removal but only up to a fixed bound
+                        if (params_base.n_ctx_checkpoints > 0 &&
+                            slot.task->type == SERVER_TASK_TYPE_COMPLETION &&
+                            (ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_FULL ||
+                             ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_RS ||
+                             n_swa > 0)) {
+                            const auto & spans = slot.task->params.message_spans;
+
+                            const int32_t n_prompt      = slot.task->n_tokens();
+                            const int32_t last_user_pos = spans.last_user_message_pos();
+
+                            std::vector<int32_t> candidates;
+
+                            // checkpoint exactly before each user message
+                            for (const auto & span : spans.spans) {
+                                if (span.role == COMMON_CHAT_ROLE_USER) {
+                                    candidates.push_back((int32_t) span.pos);
+                                }
+                            }
+
+                            // keep checkpoints near the end of the prompt:
+                            //  - 4 + n_ubatch
+                            //  - 4
+                            // clamp to n_past: if the cache already covers the tail, checkpoint at the first batch instead
+                            // ref: https://github.com/ggml-org/llama.cpp/pull/20288
+                            for (const int32_t offset : { 4 + n_ubatch, 4 }) {
+                                candidates.push_back(std::max(n_prompt - std::min(n_batch, offset), n_past));
+                            }
+
+                            std::sort(candidates.begin(), candidates.end());
+                            candidates.erase(std::unique(candidates.begin(), candidates.end()), candidates.end());
+
+                            bool    has_last = !slot.prompt.checkpoints.empty();
+                            int32_t last     = has_last ? (int32_t) slot.prompt.checkpoints.back().n_tokens : 0;
+
+                            for (const int32_t pos : candidates) {
+                                // positions before the cached prefix can never start a batch and
+                                // pos == 0 cannot be checkpointed (nothing has been decoded yet)
+                                if (pos < n_past || pos < 1 || pos >= n_prompt) {
+                                    continue;
+                                }
+
+                                // do not checkpoint at or right after mtmd chunks
+                                if (input_tokens[pos] == LLAMA_TOKEN_NULL ||
+                                    (pos > n_past && input_tokens[pos - 1] == LLAMA_TOKEN_NULL)) {
+                                    continue;
+                                }
+
+                                // no need to create checkpoints that are too close together, unless it's the last user message
+                                if (has_last && pos != last_user_pos && pos <= last + params_base.checkpoint_min_step) {
+                                    continue;
+                                }
+
+                                slot.checkpoint_pos.push_back(pos);
+
+                                has_last = true;
+                                last     = pos;
+                            }
+
+                            if (!slot.checkpoint_pos.empty()) {
+                                std::stringstream ss;
+                                for (const auto pos : slot.checkpoint_pos) {
+                                    ss << pos << " ";
+                                }
+                                SLT_DBG(slot, "planned checkpoint positions: %s\n", ss.str().c_str());
+                            }
+                        }
+
                         // this is to signal the client that the request has started processing
                         if (slot.task->params.stream) {
                             if (slot.task->params.return_progress) {
@@ -3412,21 +3491,6 @@ private:
                         alora_disabled_id = enabled_loras[0];
                     }
 
-                    bool do_checkpoint = params_base.n_ctx_checkpoints > 0;
-
-                    // make checkpoints only for completion tasks
-                    do_checkpoint = do_checkpoint && slot.task->type == SERVER_TASK_TYPE_COMPLETION;
-
-                    // make a checkpoint of the parts of the memory that cannot be rolled back.
-                    // checkpoints are created only if:
-                    // - the model does not support partial sequence removal
-                    // - the model uses SWA (and we are not using `swa_full`)
-                    // - the model supports partial sequence removal but only up to a fixed bound
-                    do_checkpoint = do_checkpoint && (
-                            ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_FULL ||
-                            ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_RS ||
-                            n_swa > 0);
-
                     bool has_mtmd = false;
 
                     // check if we should process the image
@@ -3460,9 +3524,6 @@ private:
                         has_mtmd = true;
                     }
 
-                    const auto & spans = slot.task->params.message_spans;
-                    const auto last_user_pos = spans.last_user_message_pos();
-
                     // add prompt tokens for processing in the current batch
                     while (slot.prompt.n_tokens() < slot.task->n_tokens() && batch.size() < n_batch) {
                         // get next token to process
@@ -3490,30 +3551,10 @@ private:
 
                         slot.n_prompt_tokens_processed++;
 
-                        // stop the prompt batch exactly before a user message
-                        if (spans.is_user_start(slot.prompt.n_tokens())) {
+                        // stop the prompt batch exactly at planned checkpoint positions, so that
+                        // the next batch (and the checkpoint) starts there
+                        if (std::binary_search(slot.checkpoint_pos.begin(), slot.checkpoint_pos.end(), slot.prompt.n_tokens())) {
                             break;
-                        }
-
-                        // process the last few tokens of the prompt separately in order to allow for a checkpoint to be created.
-                        // create checkpoints that many tokens before the end of the prompt:
-                        //  - 4 + n_ubatch
-                        //  - 4
-                        // ref: https://github.com/ggml-org/llama.cpp/pull/20288
-                        if (do_checkpoint) {
-                            static const int checkpoint_offsets[] = {4 + n_ubatch, 4};
-
-                            bool should_break = false;
-                            for (int offset : checkpoint_offsets) {
-                                const int n_last = std::min(n_batch, offset);
-                                if (slot.task->n_tokens() == slot.prompt.n_tokens() + n_last) {
-                                    should_break = true;
-                                    break;
-                                }
-                            }
-                            if (should_break) {
-                                break;
-                            }
                         }
                     }
 
@@ -3521,11 +3562,6 @@ private:
                     const auto n_tokens_cur = batch.size() - n_tokens_prev;
 
                     const auto n_tokens_start = slot.prompt.n_tokens() - n_tokens_cur;
-
-                    const bool near_prompt_end = slot.task->n_tokens() < slot.prompt.n_tokens() + n_ubatch;
-
-                    const bool is_user_start = spans.is_user_start(n_tokens_start);
-                    const bool is_last_user_message = n_tokens_start == last_user_pos;
 
                     // entire prompt has been processed
                     if (slot.prompt.n_tokens() == slot.task->n_tokens()) {
@@ -3540,28 +3576,20 @@ private:
                         slot.i_batch   = batch.size() - 1;
 
                         slot.init_sampler();
-                    } else {
-                        // skip ordinary mid-prompt checkpoints, unless the batch starts a user
-                        // message or we are near the end of the prompt
-                        if (!is_user_start && !near_prompt_end) {
-                            do_checkpoint = false;
-                        }
                     }
 
                     const auto pos_min = llama_memory_seq_pos_min(llama_get_memory(ctx_tgt), slot.id);
                     const auto pos_max = llama_memory_seq_pos_max(llama_get_memory(ctx_tgt), slot.id);
 
+                    // create a checkpoint only if the batch starts exactly at a planned position
+                    bool do_checkpoint = std::binary_search(slot.checkpoint_pos.begin(), slot.checkpoint_pos.end(), n_tokens_start);
+
                     // nothing to checkpoint yet
-                    // TODO: is this check needed?
-                    if (do_checkpoint && pos_min < 0) {
-                        do_checkpoint = false;
-                    }
+                    do_checkpoint = do_checkpoint && pos_min >= 0;
 
                     // do not checkpoint after mtmd chunks
                     do_checkpoint = do_checkpoint && !has_mtmd;
 
-                    // no need to create checkpoints that are too close together, unless it's the last user message
-                    do_checkpoint = do_checkpoint && (slot.prompt.checkpoints.empty() || is_last_user_message || n_tokens_start > slot.prompt.checkpoints.back().n_tokens + params_base.checkpoint_min_step);
                     SLT_DBG(slot, "main/do_checkpoint = %s, pos_min = %d, pos_max = %d\n", do_checkpoint ? "yes" : "no", pos_min, pos_max);
 
                     // note: we create the checkpoint before calling llama_decode(), so the current batch is not

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -3496,8 +3496,6 @@ private:
                     // a checkpoint is created before decoding the current batch if it starts at a planned position
                     const bool checkpoint_at_start = checkpoint_pos.count(slot.prompt.n_tokens()) != 0;
 
-                    bool has_mtmd = false;
-
                     // check if we should process the image
                     while (true) {
                         auto cur_token_idx = slot.prompt.n_tokens();
@@ -3525,8 +3523,6 @@ private:
                             const auto & chunk = input_tokens.find_chunk(cur_token_idx);
                             slot.prompt.tokens.push_back(chunk.get()); // copy
                         }
-
-                        has_mtmd = true;
                     }
 
                     // add prompt tokens for processing in the current batch
@@ -3589,9 +3585,6 @@ private:
 
                     // nothing to checkpoint yet
                     do_checkpoint = do_checkpoint && pos_min >= 0;
-
-                    // do not checkpoint after mtmd chunks
-                    do_checkpoint = do_checkpoint && !has_mtmd;
 
                     SLT_DBG(slot, "main/do_checkpoint = %s, pos_min = %d, pos_max = %d\n", do_checkpoint ? "yes" : "no", pos_min, pos_max);
 

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -3429,7 +3429,7 @@ private:
 
                     // determine ahead of time the positions at which context checkpoints will be created,
                     // so that the prompt batches are split only at positions where a checkpoint is actually created
-                    std::vector<int32_t> checkpoint_pos;
+                    std::set<int32_t> checkpoint_pos;
 
                     if (do_checkpoint) {
                         const auto & spans = slot.task->params.message_spans;
@@ -3478,7 +3478,7 @@ private:
                                 continue;
                             }
 
-                            checkpoint_pos.push_back(pos);
+                            checkpoint_pos.insert(pos);
 
                             has_last = true;
                             last     = pos;
@@ -3494,7 +3494,7 @@ private:
                     }
 
                     // a checkpoint is created before decoding the current batch if it starts at a planned position
-                    const bool checkpoint_at_start = !checkpoint_pos.empty() && checkpoint_pos.front() == slot.prompt.n_tokens();
+                    const bool checkpoint_at_start = checkpoint_pos.count(slot.prompt.n_tokens()) != 0;
 
                     bool has_mtmd = false;
 
@@ -3529,9 +3529,6 @@ private:
                         has_mtmd = true;
                     }
 
-                    // the next planned checkpoint position, advanced as the batch is filled
-                    auto it_ckpt = checkpoint_pos.cbegin();
-
                     // add prompt tokens for processing in the current batch
                     while (slot.prompt.n_tokens() < slot.task->n_tokens() && batch.size() < n_batch) {
                         // get next token to process
@@ -3561,10 +3558,7 @@ private:
 
                         // stop the prompt batch exactly at planned checkpoint positions, so that
                         // the next batch (and the checkpoint) starts there
-                        while (it_ckpt != checkpoint_pos.cend() && *it_ckpt < slot.prompt.n_tokens()) {
-                            ++it_ckpt;
-                        }
-                        if (it_ckpt != checkpoint_pos.cend() && *it_ckpt == slot.prompt.n_tokens()) {
+                        if (checkpoint_pos.count(slot.prompt.n_tokens()) != 0) {
                             break;
                         }
                     }

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -3412,19 +3412,26 @@ private:
                         alora_disabled_id = enabled_loras[0];
                     }
 
+                    bool do_checkpoint = params_base.n_ctx_checkpoints > 0;
+
+                    // make checkpoints only for completion tasks
+                    do_checkpoint = do_checkpoint && slot.task->type == SERVER_TASK_TYPE_COMPLETION;
+
+                    // make a checkpoint of the parts of the memory that cannot be rolled back.
+                    // checkpoints are created only if:
+                    // - the model does not support partial sequence removal
+                    // - the model uses SWA (and we are not using `swa_full`)
+                    // - the model supports partial sequence removal but only up to a fixed bound
+                    do_checkpoint = do_checkpoint && (
+                            ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_FULL ||
+                            ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_RS ||
+                            n_swa > 0);
+
                     // determine ahead of time the positions at which context checkpoints will be created,
                     // so that the prompt batches are split only at positions where a checkpoint is actually created
                     std::vector<int32_t> checkpoint_pos;
 
-                    // make checkpoints only for completion tasks and only if:
-                    // - the model does not support partial sequence removal
-                    // - the model uses SWA (and we are not using `swa_full`)
-                    // - the model supports partial sequence removal but only up to a fixed bound
-                    if (params_base.n_ctx_checkpoints > 0 &&
-                        slot.task->type == SERVER_TASK_TYPE_COMPLETION &&
-                        (ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_FULL ||
-                         ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_RS ||
-                         n_swa > 0)) {
+                    if (do_checkpoint) {
                         const auto & spans = slot.task->params.message_spans;
 
                         const int32_t n_prompt      = slot.task->n_tokens();
@@ -3584,7 +3591,7 @@ private:
                     const auto pos_max = llama_memory_seq_pos_max(llama_get_memory(ctx_tgt), slot.id);
 
                     // create a checkpoint only if the batch starts exactly at a planned position
-                    bool do_checkpoint = checkpoint_at_start;
+                    do_checkpoint = do_checkpoint && checkpoint_at_start;
 
                     // nothing to checkpoint yet
                     do_checkpoint = do_checkpoint && pos_min >= 0;

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -3431,12 +3431,12 @@ private:
                         const int32_t n_cur         = slot.prompt.n_tokens();
                         const int32_t last_user_pos = spans.last_user_message_pos();
 
-                        std::vector<int32_t> candidates;
+                        std::set<int32_t> candidates;
 
                         // checkpoint exactly before each user message
                         for (const auto & span : spans.spans) {
                             if (span.role == COMMON_CHAT_ROLE_USER) {
-                                candidates.push_back((int32_t) span.pos);
+                                candidates.insert((int32_t) span.pos);
                             }
                         }
 
@@ -3447,11 +3447,8 @@ private:
                         // checkpoint at the start of the current batch instead
                         // ref: https://github.com/ggml-org/llama.cpp/pull/20288
                         for (const int32_t offset : { 4 + n_ubatch, 4 }) {
-                            candidates.push_back(std::max(n_prompt - std::min(n_batch, offset), n_cur));
+                            candidates.insert(std::max(n_prompt - std::min(n_batch, offset), n_cur));
                         }
-
-                        std::sort(candidates.begin(), candidates.end());
-                        candidates.erase(std::unique(candidates.begin(), candidates.end()), candidates.end());
 
                         bool    has_last = !slot.prompt.checkpoints.empty();
                         int32_t last     = has_last ? (int32_t) slot.prompt.checkpoints.back().n_tokens : 0;

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -215,9 +215,6 @@ struct server_slot {
 
     server_prompt prompt;
 
-    // positions where context checkpoints will be created for the current task (ascending, unique)
-    std::vector<int32_t> checkpoint_pos;
-
     bool prompt_save(server_prompt_cache & prompt_cache) const {
         if (prompt.tokens.size() == 0) {
             return false;
@@ -320,7 +317,6 @@ struct server_slot {
         }
         generated_tokens.clear();
         generated_token_probs.clear();
-        checkpoint_pos.clear();
         json_schema = json();
 
         // clear speculative decoding stats
@@ -3369,81 +3365,6 @@ private:
 
                         slot.prompt.tokens.keep_first(n_past);
 
-                        // determine ahead of time the positions at which context checkpoints will be created,
-                        // so that the prompt batches are split only at positions where a checkpoint is actually created
-                        slot.checkpoint_pos.clear();
-
-                        // make checkpoints only for completion tasks and only if:
-                        // - the model does not support partial sequence removal
-                        // - the model uses SWA (and we are not using `swa_full`)
-                        // - the model supports partial sequence removal but only up to a fixed bound
-                        if (params_base.n_ctx_checkpoints > 0 &&
-                            slot.task->type == SERVER_TASK_TYPE_COMPLETION &&
-                            (ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_FULL ||
-                             ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_RS ||
-                             n_swa > 0)) {
-                            const auto & spans = slot.task->params.message_spans;
-
-                            const int32_t n_prompt      = slot.task->n_tokens();
-                            const int32_t last_user_pos = spans.last_user_message_pos();
-
-                            std::vector<int32_t> candidates;
-
-                            // checkpoint exactly before each user message
-                            for (const auto & span : spans.spans) {
-                                if (span.role == COMMON_CHAT_ROLE_USER) {
-                                    candidates.push_back((int32_t) span.pos);
-                                }
-                            }
-
-                            // keep checkpoints near the end of the prompt:
-                            //  - 4 + n_ubatch
-                            //  - 4
-                            // clamp to n_past: if the cache already covers the tail, checkpoint at the first batch instead
-                            // ref: https://github.com/ggml-org/llama.cpp/pull/20288
-                            for (const int32_t offset : { 4 + n_ubatch, 4 }) {
-                                candidates.push_back(std::max(n_prompt - std::min(n_batch, offset), n_past));
-                            }
-
-                            std::sort(candidates.begin(), candidates.end());
-                            candidates.erase(std::unique(candidates.begin(), candidates.end()), candidates.end());
-
-                            bool    has_last = !slot.prompt.checkpoints.empty();
-                            int32_t last     = has_last ? (int32_t) slot.prompt.checkpoints.back().n_tokens : 0;
-
-                            for (const int32_t pos : candidates) {
-                                // positions before the cached prefix can never start a batch and
-                                // pos == 0 cannot be checkpointed (nothing has been decoded yet)
-                                if (pos < n_past || pos < 1 || pos >= n_prompt) {
-                                    continue;
-                                }
-
-                                // do not checkpoint at or right after mtmd chunks
-                                if (input_tokens[pos] == LLAMA_TOKEN_NULL ||
-                                    (pos > n_past && input_tokens[pos - 1] == LLAMA_TOKEN_NULL)) {
-                                    continue;
-                                }
-
-                                // no need to create checkpoints that are too close together, unless it's the last user message
-                                if (has_last && pos != last_user_pos && pos <= last + params_base.checkpoint_min_step) {
-                                    continue;
-                                }
-
-                                slot.checkpoint_pos.push_back(pos);
-
-                                has_last = true;
-                                last     = pos;
-                            }
-
-                            if (!slot.checkpoint_pos.empty()) {
-                                std::stringstream ss;
-                                for (const auto pos : slot.checkpoint_pos) {
-                                    ss << pos << " ";
-                                }
-                                SLT_DBG(slot, "planned checkpoint positions: %s\n", ss.str().c_str());
-                            }
-                        }
-
                         // this is to signal the client that the request has started processing
                         if (slot.task->params.stream) {
                             if (slot.task->params.return_progress) {
@@ -3491,6 +3412,86 @@ private:
                         alora_disabled_id = enabled_loras[0];
                     }
 
+                    // determine ahead of time the positions at which context checkpoints will be created,
+                    // so that the prompt batches are split only at positions where a checkpoint is actually created
+                    std::vector<int32_t> checkpoint_pos;
+
+                    // make checkpoints only for completion tasks and only if:
+                    // - the model does not support partial sequence removal
+                    // - the model uses SWA (and we are not using `swa_full`)
+                    // - the model supports partial sequence removal but only up to a fixed bound
+                    if (params_base.n_ctx_checkpoints > 0 &&
+                        slot.task->type == SERVER_TASK_TYPE_COMPLETION &&
+                        (ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_FULL ||
+                         ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_RS ||
+                         n_swa > 0)) {
+                        const auto & spans = slot.task->params.message_spans;
+
+                        const int32_t n_prompt      = slot.task->n_tokens();
+                        const int32_t n_cur         = slot.prompt.n_tokens();
+                        const int32_t last_user_pos = spans.last_user_message_pos();
+
+                        std::vector<int32_t> candidates;
+
+                        // checkpoint exactly before each user message
+                        for (const auto & span : spans.spans) {
+                            if (span.role == COMMON_CHAT_ROLE_USER) {
+                                candidates.push_back((int32_t) span.pos);
+                            }
+                        }
+
+                        // keep checkpoints near the end of the prompt:
+                        //  - 4 + n_ubatch
+                        //  - 4
+                        // clamp to the current position: if the cache already covers the tail,
+                        // checkpoint at the start of the current batch instead
+                        // ref: https://github.com/ggml-org/llama.cpp/pull/20288
+                        for (const int32_t offset : { 4 + n_ubatch, 4 }) {
+                            candidates.push_back(std::max(n_prompt - std::min(n_batch, offset), n_cur));
+                        }
+
+                        std::sort(candidates.begin(), candidates.end());
+                        candidates.erase(std::unique(candidates.begin(), candidates.end()), candidates.end());
+
+                        bool    has_last = !slot.prompt.checkpoints.empty();
+                        int32_t last     = has_last ? (int32_t) slot.prompt.checkpoints.back().n_tokens : 0;
+
+                        for (const int32_t pos : candidates) {
+                            // positions before the current one can never start a batch and
+                            // pos == 0 cannot be checkpointed (nothing has been decoded yet)
+                            if (pos < n_cur || pos < 1 || pos >= n_prompt) {
+                                continue;
+                            }
+
+                            // do not checkpoint at or right after mtmd chunks
+                            if (input_tokens[pos] == LLAMA_TOKEN_NULL ||
+                                (pos > n_cur && input_tokens[pos - 1] == LLAMA_TOKEN_NULL)) {
+                                continue;
+                            }
+
+                            // no need to create checkpoints that are too close together, unless it's the last user message
+                            if (has_last && pos != last_user_pos && pos <= last + params_base.checkpoint_min_step) {
+                                continue;
+                            }
+
+                            checkpoint_pos.push_back(pos);
+
+                            has_last = true;
+                            last     = pos;
+                        }
+
+                        if (!checkpoint_pos.empty()) {
+                            std::stringstream ss;
+                            for (const auto pos : checkpoint_pos) {
+                                ss << pos << " ";
+                            }
+                            SLT_DBG(slot, "planned checkpoint positions: %s\n", ss.str().c_str());
+                        }
+                    }
+
+                    // a checkpoint is created before decoding the current batch if it starts at a planned position
+                    const bool checkpoint_at_start = !checkpoint_pos.empty() && checkpoint_pos.front() == slot.prompt.n_tokens();
+
                     bool has_mtmd = false;
 
                     // check if we should process the image
@@ -3524,6 +3525,9 @@ private:
                         has_mtmd = true;
                     }
 
+                    // the next planned checkpoint position, advanced as the batch is filled
+                    auto it_ckpt = checkpoint_pos.cbegin();
+
                     // add prompt tokens for processing in the current batch
                     while (slot.prompt.n_tokens() < slot.task->n_tokens() && batch.size() < n_batch) {
                         // get next token to process
@@ -3553,15 +3557,16 @@ private:
 
                         // stop the prompt batch exactly at planned checkpoint positions, so that
                         // the next batch (and the checkpoint) starts there
-                        if (std::binary_search(slot.checkpoint_pos.begin(), slot.checkpoint_pos.end(), slot.prompt.n_tokens())) {
+                        while (it_ckpt != checkpoint_pos.cend() && *it_ckpt < slot.prompt.n_tokens()) {
+                            ++it_ckpt;
+                        }
+                        if (it_ckpt != checkpoint_pos.cend() && *it_ckpt == slot.prompt.n_tokens()) {
                             break;
                         }
                     }
 
                     // the number of tokens added to the batch for the current slot
                     const auto n_tokens_cur = batch.size() - n_tokens_prev;
-
-                    const auto n_tokens_start = slot.prompt.n_tokens() - n_tokens_cur;
 
                     // entire prompt has been processed
                     if (slot.prompt.n_tokens() == slot.task->n_tokens()) {
@@ -3582,7 +3587,7 @@ private:
                     const auto pos_max = llama_memory_seq_pos_max(llama_get_memory(ctx_tgt), slot.id);
 
                     // create a checkpoint only if the batch starts exactly at a planned position
-                    bool do_checkpoint = std::binary_search(slot.checkpoint_pos.begin(), slot.checkpoint_pos.end(), n_tokens_start);
+                    bool do_checkpoint = checkpoint_at_start;
 
                     // nothing to checkpoint yet
                     do_checkpoint = do_checkpoint && pos_min >= 0;


### PR DESCRIPTION
Only split the prompt batch at positions where a checkpoint will
actually be created, instead of breaking at every candidate position
and applying the constraints afterwards.

Assisted-by: Claude