### PR TITLE
server : split prompt batch at user messages only outside checkpoint min step

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -3463,6 +3463,13 @@ private:
                     const auto & spans = slot.task->params.message_spans;
                     const auto last_user_pos = spans.last_user_message_pos();
 
+                    // the last user break: the last checkpoint, or the batch start if it is a user message
+                    int64_t last_break_pos = slot.prompt.checkpoints.empty() ? -1 : slot.prompt.checkpoints.back().n_tokens;
+
+                    if (slot.prompt.n_tokens() > 0 && spans.is_user_start(slot.prompt.n_tokens())) {
+                        last_break_pos = std::max(last_break_pos, (int64_t) slot.prompt.n_tokens());
+                    }
+
                     // add prompt tokens for processing in the current batch
                     while (slot.prompt.n_tokens() < slot.task->n_tokens() && batch.size() < n_batch) {
                         // get next token to process
@@ -3490,9 +3497,13 @@ private:
 
                         slot.n_prompt_tokens_processed++;
 
-                        // stop the prompt batch exactly before a user message
-                        if (spans.is_user_start(slot.prompt.n_tokens())) {
-                            break;
+                        // break at the last user message, or at user messages at least min step past the last break
+                        if (do_checkpoint && spans.is_user_start(slot.prompt.n_tokens())) {
+                            const auto pos = slot.prompt.n_tokens();
+
+                            if (pos == last_user_pos || last_break_pos < 0 || pos > last_break_pos + params_base.checkpoint_min_step) {
+                                break;
+                            }
                         }
 
                         // process the last few tokens of the prompt separately in order to allow for a checkpoint to be created.


### PR DESCRIPTION
Record the position of the last user-message break and skip breaks that
fall within checkpoint_min_step of it, since no checkpoint would be
created there anyway. Also skip user-message breaks entirely when
checkpointing is disabled.

Assisted-by: Claude

---

<details>
<summary>Conversation transcript</summary>

**User:**

> Look at PR https://github.com/aldehir/llama.cpp/pull/21, let's try to solve the same problem but instead just record the position of the last user break in the loop and only break if we're outside if min step.

**Claude:**

Reviewed PR #21 and the current code on master. The problem: the batch-fill loop breaks at every user message start, but the checkpoint min-step constraint is applied only after the loop, so batches get split at positions where no checkpoint is actually created.

Implemented the requested approach in `tools/server/server-context.cpp`:

- Before the loop, `last_break_pos` records where the last user break effectively happened: the last created checkpoint, or the current batch start when it falls on a user message (the checkpoint for that break is only created after the loop, so `checkpoints.back()` alone would lag one batch behind).
- In the loop, a user-message position only breaks the batch if it is the last user message (always breaks, matching the existing checkpoint exemption), or it is more than `checkpoint_min_step` past `last_break_pos`.
- The break is also gated on `do_checkpoint`, so when checkpointing is disabled the prompt no longer gets split at user messages at all.

The post-loop checkpoint constraints are left untouched as the actual decision point; the loop now just avoids splitting where they would reject the checkpoint anyway. The tail-of-prompt breaks (`4 + n_ubatch`, `4`) are left as-is, so those can still occasionally split without producing a checkpoint (bounded to 2 per prompt).

**User:**

> We also always want to break at the last user message, but those up to it should be constrained by min-step
>
> And make the comments one liners, keep it brief

**Claude:**

The last-user-message behavior was already in place (`pos == last_user_pos` always breaks, earlier ones are min-step constrained). Trimmed the comments to one-liners and amended the commit.

**User:**

> Now that we have this in place, do we still need to check it again towards the bottom in the do_checkpoint logic?

**Claude:**

Yes, keep it. The bottom check (`checkpoints.empty() || is_last_user_message || n_tokens_start > checkpoints.back().n_tokens + checkpoint_min_step`) fires on the batch start, and there are three ways a batch can start at a checkpointable position:

1. The previous batch broke at a user message. This is the redundant case: the loop only breaks beyond `last_break_pos + min_step`, and `last_break_pos >= checkpoints.back().n_tokens` at that point, so the bottom check always passes.
2. Near-prompt-end checkpoints. The tail-offset breaks and the `near_prompt_end` path are not min-step gated in the loop. If the last checkpoint (often the one at the last user message) sits within `min_step` of the prompt tail, the bottom check is the only thing preventing a redundant checkpoint a few tokens later.
3. Cache reuse. A batch can start on a user message because that is simply where the prompt cache ended, not because of a gated break. If an existing checkpoint is within `min_step` of that position, the bottom check is again the only guard. Its `is_last_user_message` exemption is also what lets the always-break-at-last-user-message actually produce its checkpoint in that situation.

So the loop gate is purely a batch-splitting optimization; the bottom check remains the single source of truth for the checkpoint decision.

**User:**

> I still want to create the first checkpoint even if it's within min-step of pos 0

**Claude:**

The code as committed already does this. The first-checkpoint exemption lives in the `last_break_pos < 0` arm of the break condition: with no checkpoints, `last_break_pos` starts at -1, and the `slot.prompt.n_tokens() > 0` guard on the derivation deliberately refuses to count position 0 as a break (nothing has been decoded yet, so no checkpoint can be created there). The first user message therefore breaks unconditionally, and the checkpoint is created at that position through the bottom check's `checkpoints.empty()` arm, regardless of min-step. The two conditions mirror each other by design: `last_break_pos < 0` corresponds to `checkpoints.empty()`, `pos == last_user_pos` to `is_last_user_message`, and the `> min_step` comparison to the `checkpoints.back()` comparison.

**User:**

> Are you able to modify the pr description and include a transcript of our conversation?

**Claude:**

Updated this description with the transcript.

</details>