### PR TITLE
chat : tighten bare function parsing for Qwen models

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -1166,6 +1166,16 @@ static common_chat_params common_chat_params_init_qwen3_coder(const common_chat_
         data.prompt += data.generation_prompt;
     }
 
+    std::vector<std::string> tool_call_starts = { "<tool_call>" };
+
+    // Match complete <function=name> opener for Qwen3-Coder models that occasionally omit the
+    // starting <tool_call>. The model may hallucinate a tool name, but it is preferable over
+    // constraining on <function which may occur in valid content generation, e.g. #include <functional>
+    foreach_function(inputs.tools, [&](const json & tool) {
+        const std::string name = tool.at("function").at("name");
+        tool_call_starts.push_back("<function=" + name + ">");
+    });
+
     auto parser = build_chat_peg_parser([&](common_chat_peg_builder & p) {
         auto generation_prompt = p.literal(GEN_PREFIX);
 
@@ -1238,7 +1248,7 @@ static common_chat_params common_chat_params_init_qwen3_coder(const common_chat_
             auto tool_calls = p.trigger_rule("tool-call-root", p.repeat(calls, min_calls, 1));
 
             return generation_prompt +
-                   (reasoning << p.content(p.until_one_of({ "<tool_call>", "<function=" })) << tool_calls);
+                   (reasoning << p.content(p.until_one_of(tool_call_starts)) << tool_calls);
         }
 
         // Content only parser
@@ -1264,12 +1274,9 @@ static common_chat_params common_chat_params_init_qwen3_coder(const common_chat_
         });
 
         if (data.grammar_lazy) {
-            data.grammar_triggers = {
-                { COMMON_GRAMMAR_TRIGGER_TYPE_WORD, "<tool_call>" },
-                // Trigger on "<function" and not "<function=" because the trailing "=" is part of
-                // the token with the function name e.g. "=read"
-                { COMMON_GRAMMAR_TRIGGER_TYPE_WORD, "<function"   },
-            };
+            for (const auto & start : tool_call_starts) {
+                data.grammar_triggers.push_back({ COMMON_GRAMMAR_TRIGGER_TYPE_WORD, start });
+            }
         }
     }
 


### PR DESCRIPTION
## Overview

The lazy tool-call grammar built for the Qwen3-Coder style templates triggers on the bare word `<function`. Trigger patterns are matched with `std::regex_search` over the whole buffered output, so the trigger also fires when `<function` appears inside an ordinary word. `#include <functional>` is the common case: any coding model writing C++ hits it.

On a spurious match the buffered token pieces are replayed into the grammar without validation. The replayed text cannot match the tool call rules, every stack dies, and `llama_grammar_accept_token()` throws:

```
got exception: Unexpected empty grammar stack after accepting piece: functional (47573)
```

The request is aborted with HTTP 500 and the slot is released.

This derives the exact tool call openers instead: `<tool_call>`, plus `<function=NAME>` for each declared tool. The same list feeds both the PEG content boundary (`until_one_of`) and the grammar triggers, so the parser and the grammar cannot disagree about where a tool call starts.

Affects every template routed through `common_chat_params_init_qwen3_coder`.

## Additional information

Reproduced with Qwen3.6-27B-UD-Q4_K_XL, `--jinja`, one tool declared, asking for C++ that includes `<functional>`:

- before: 4/4 seeds returned HTTP 500
- after: 4/4 seeds pass, `<functional>` is returned as normal content
- same request without tools never failed, confirming the lazy tool-call grammar as the cause

Tool calling verified unchanged for `tool_choice` auto and required, including parallel calls. `test-chat`, `test-chat-peg-parser` and `test-chat-auto-parser` pass.

Note this narrows the false positive window rather than closing it. The grammar still activates on a literal `<function=NAME>` appearing in prose or a fenced code block, and the replay is still fatal when the text then diverges. A guard in `llama_grammar_accept_impl` that restores the pre-replay state instead of throwing would be the general fix, and is not part of this change.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - agent-assisted. The design (trigger on exact `<function=NAME>` openers, and keep the content parser in sync with it) is mine. An agent reproduced the failure, wrote the change to that design, ran the tests, and drafted this description.
